### PR TITLE
some fix about spell-error and mutex and code style.

### DIFF
--- a/consistenthash/consistenthash.go
+++ b/consistenthash/consistenthash.go
@@ -54,7 +54,8 @@ func (m *Map) IsEmpty() bool {
 func (m *Map) Add(keys ...string) {
 	for _, key := range keys {
 		for i := 0; i < m.replicas; i++ {
-			hash := int(m.hash([]byte(strconv.Itoa(i) + key)))
+			// use replicas id + _ + key to avoid the key has pre-number.
+			hash := int(m.hash([]byte(strconv.Itoa(i) + "_" + key)))
 			if m.hashMap[hash] == "" {
 				m.keys = append(m.keys, hash)
 				m.hashMap[hash] = key

--- a/dcron.go
+++ b/dcron.go
@@ -2,12 +2,14 @@ package dcron
 
 import (
 	"errors"
-	"github.com/libi/dcron/driver"
-	"github.com/robfig/cron/v3"
 	"log"
 	"os"
 	"sync/atomic"
 	"time"
+
+	"github.com/libi/dcron/dlog"
+	"github.com/libi/dcron/driver"
+	"github.com/robfig/cron/v3"
 )
 
 const (
@@ -27,7 +29,7 @@ type Dcron struct {
 	nodePool   *NodePool
 	running    int32
 
-	logger  interface{ Printf(string, ...interface{}) }
+	logger  dlog.Logger
 	logInfo bool
 
 	nodeUpdateDuration time.Duration
@@ -87,7 +89,7 @@ func (d *Dcron) SetLogger(logger *log.Logger) {
 }
 
 // GetLogger get dcron logger
-func (d *Dcron) GetLogger() interface{ Printf(string, ...interface{}) } {
+func (d *Dcron) GetLogger() dlog.Logger {
 	return d.logger
 }
 

--- a/dlog/logger.go
+++ b/dlog/logger.go
@@ -1,0 +1,5 @@
+package dlog
+
+type Logger interface {
+	Printf(string, ...interface{})
+}

--- a/option.go
+++ b/option.go
@@ -1,15 +1,17 @@
 package dcron
 
 import (
-	"github.com/robfig/cron/v3"
 	"time"
+
+	"github.com/libi/dcron/dlog"
+	"github.com/robfig/cron/v3"
 )
 
 // Option is Dcron Option
 type Option func(*Dcron)
 
 // WithLogger both set dcron and cron logger.
-func WithLogger(logger interface{ Printf(string, ...interface{}) }) Option {
+func WithLogger(logger dlog.Logger) Option {
 	return func(dcron *Dcron) {
 		//set dcron logger
 		dcron.logger = logger


### PR DESCRIPTION
1. fix filename spell error
2. change the log interface
3. use rwmutex take the place of mutex
4. use an independent interface dlog.Logger instead of interface {Print ... }