### PR TITLE
Use redis universal client

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -3,7 +3,7 @@ package driver
 import (
 	"context"
 
-	redis "github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
@@ -30,7 +30,7 @@ type DriverV2 interface {
 	withOption(opt Option) (err error)
 }
 
-func NewRedisDriver(redisClient *redis.Client) DriverV2 {
+func NewRedisDriver(redisClient redis.UniversalClient) DriverV2 {
 	return newRedisDriver(redisClient)
 }
 
@@ -38,6 +38,6 @@ func NewEtcdDriver(etcdCli *clientv3.Client) DriverV2 {
 	return newEtcdDriver(etcdCli)
 }
 
-func NewRedisZSetDriver(redisClient *redis.Client) DriverV2 {
+func NewRedisZSetDriver(redisClient redis.UniversalClient) DriverV2 {
 	return newRedisZSetDriver(redisClient)
 }

--- a/driver/redisdriver.go
+++ b/driver/redisdriver.go
@@ -17,7 +17,7 @@ const (
 )
 
 type RedisDriver struct {
-	c           *redis.Client
+	c           redis.UniversalClient
 	serviceName string
 	nodeID      string
 	timeout     time.Duration
@@ -32,7 +32,7 @@ type RedisDriver struct {
 	sync.Mutex
 }
 
-func newRedisDriver(redisClient *redis.Client) *RedisDriver {
+func newRedisDriver(redisClient redis.UniversalClient) *RedisDriver {
 	rd := &RedisDriver{
 		c: redisClient,
 		logger: &dlog.StdLogger{

--- a/driver/rediszsetdriver.go
+++ b/driver/rediszsetdriver.go
@@ -13,7 +13,7 @@ import (
 )
 
 type RedisZSetDriver struct {
-	c           *redis.Client
+	c           redis.UniversalClient
 	serviceName string
 	nodeID      string
 	timeout     time.Duration
@@ -28,7 +28,7 @@ type RedisZSetDriver struct {
 	sync.Mutex
 }
 
-func newRedisZSetDriver(redisClient *redis.Client) *RedisZSetDriver {
+func newRedisZSetDriver(redisClient redis.UniversalClient) *RedisZSetDriver {
 	rd := &RedisZSetDriver{
 		c: redisClient,
 		logger: &dlog.StdLogger{


### PR DESCRIPTION
UniversalClient is a wrapper client which, based on the provided options, represents either a ClusterClient, a FailoverClient, or a single-node Client. This can be useful for testing cluster-specific applications locally or having different clients in different environments.