### PR TITLE
Added compatible logger injection

### DIFF
--- a/dlog/logrus.go
+++ b/dlog/logrus.go
@@ -1,0 +1,27 @@
+package dlog
+
+import "github.com/sirupsen/logrus"
+
+type LogrusLoggerImpl struct {
+	log *logrus.Logger
+}
+
+func (l *LogrusLoggerImpl) Printf(format string, args ...any) {
+	l.log.Printf(format, args...)
+}
+
+func (l *LogrusLoggerImpl) Infof(format string, args ...any) {
+	l.log.Infof(format, args...)
+}
+
+func (l *LogrusLoggerImpl) Warnf(format string, args ...any) {
+	l.log.Warnf(format, args...)
+}
+
+func (l *LogrusLoggerImpl) Errorf(format string, args ...any) {
+	l.log.Errorf(format, args...)
+}
+
+func NewLogrusLogger(logger *logrus.Logger) Logger {
+	return &LogrusLoggerImpl{log: logger}
+}

--- a/dlog/zap.go
+++ b/dlog/zap.go
@@ -1,0 +1,27 @@
+package dlog
+
+import "go.uber.org/zap"
+
+type ZapLoggerImpl struct {
+	log *zap.Logger
+}
+
+func (l *ZapLoggerImpl) Printf(format string, args ...any) {
+	l.log.Sugar().Infof(format, args...)
+}
+
+func (l *ZapLoggerImpl) Infof(format string, args ...any) {
+	l.log.Sugar().Infof(format, args...)
+}
+
+func (l *ZapLoggerImpl) Warnf(format string, args ...any) {
+	l.log.Sugar().Warnf(format, args...)
+}
+
+func (l *ZapLoggerImpl) Errorf(format string, args ...any) {
+	l.log.Sugar().Errorf(format, args...)
+}
+
+func NewZapLogger(logger *zap.Logger) Logger {
+	return &ZapLoggerImpl{log: logger}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/alicebob/miniredis/v2 v2.31.0
 	github.com/google/uuid v1.4.0
 	github.com/redis/go-redis/v9 v9.3.1
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	go.etcd.io/etcd/api/v3 v3.5.11
 	go.etcd.io/etcd/client/v3 v3.5.11
 	go.etcd.io/etcd/tests/v3 v3.5.11
+	go.uber.org/zap v1.26.0
 )
 
 require (
@@ -44,7 +46,6 @@ require (
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
@@ -65,7 +66,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect


### PR DESCRIPTION
In the production environment, we often use a globally unique logger and cooperate with ELK, etc. to collect data. It may be necessary to add an implementation of a common logger.