### PR TITLE
fix REAME_CN about driver

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -38,7 +38,7 @@ redisCli := redis.NewClient(&redis.Options{
 drv := redisdriver.NewDriver(redisCli)
 dcron := NewDcron("server1", drv)
 ```
-当然，如果你可以自己实现一个自定义的Driver也是可以的，只需要实现[DriverV2](driver/driver.go)接口即可。
+当然，如果你可以自己实现一个自定义的Driver也是可以的，只需要实现[DriverV2](https://github.com/dcron-contrib/commons/blob/main/driver.go)接口即可。
 
 2.使用cron语法添加任务，需要指定任务名。任务名作为任务的唯一标识，必须保证唯一。
 ```golang


### PR DESCRIPTION
0.6.0 版本剥离了 dirver 到独立的仓库，但是中文 README 内仍有指向原位置的文档